### PR TITLE
Create exception for natural language test

### DIFF
--- a/.github/linters/.textlintrc
+++ b/.github/linters/.textlintrc
@@ -1,0 +1,8 @@
+{
+  "filters": {
+    "comments": true
+  },
+  "rules": {
+    "terminology": true
+  }
+}

--- a/README.md
+++ b/README.md
@@ -38,7 +38,11 @@ The repository comes with the following preset files:
 
 Once you've created your repository using this template, perform the following steps:
 
+<!-- textlint-disable -->
+
 ### Update README
+
+<!-- textlint-enable -->
 
 Edit this README.md file to document your project accurately. Take the time to create a clear, engaging, and informative README.md file. Include information like what your project does, how to install and run it, how to contribute, and any other pertinent details.
 
@@ -62,11 +66,19 @@ Please read and understand these standards thoroughly and enable them when you f
 
 ### Modify the GitHub Repository Standards Badge
 
+<!-- textlint-disable -->
+
 Once you've ensured that all the [GitHub Repository Standards](https://operations-engineering.service.justice.gov.uk/documentation/services/repository-standards.html) have been applied to your repository, it's time to update the Ministry of Justice (MoJ) Compliance Badge located in the README file.
+
+<!-- textlint-enable -->
 
 The badge demonstrates that your repository is compliant with MoJ's standards. Please follow these [instructions](https://operations-engineering.service.justice.gov.uk/documentation/runbooks/services/add-repo-badge.html) to modify the badge URL to reflect the status of your repository correctly.
 
+<!-- textlint-disable -->
+
 **Please note** the badge will not function correctly if your repository is internal or private. In this case, you may remove the badge from your README.
+
+<!-- textlint-enable -->
 
 ### Manage Outside Collaborators
 


### PR DESCRIPTION
the super linter natural language check has been alerting on the word README in the README.me for this repo

This PR creates a Textlint exception to skip the occurrences of this word.